### PR TITLE
Guideline on Attribution

### DIFF
--- a/_posts/2022-02-01-attribution.md
+++ b/_posts/2022-02-01-attribution.md
@@ -7,19 +7,51 @@ category: Open Science
 tags: attribution
 ---
 
-<div style="text-align: justify">
+
 More and more often, contemporary research is conducted by a number of young and senior researchers actively collaborating and contributing to a common project, answering an increasingly multidisplinary range of questions. 
 
-To ensure all the people involved in the research process are rightfully acknolwegded, the [Contributor Roles Taxonomy, known as CRediT author statement][1] was created. The CRediT taxonomy clearlry provides definitions for a wide range of roles to describe the personal contributions that a researcher might bring to a collaborative project. It also aims at providing a definition for what authorship should mean and acknowledge, in the case of scientific research, by broadening the concept to include all intellectual and practical contributors to the final output. 
+To ensure all the people involved in the research process are rightfully acknolwegded, the [CRediT author statement][1] was introduced in the scientific publishing process. The CRediT author statement relies on the [Contributor Roles Taxonomy][2] to clearly define a wide range of roles to describe the personal contributions that a researcher might bring to a collaborative project. It also aims at providing a definition for what authorship should mean and acknowledge, in the case of scientific research, by broadening the concept to include all intellectual and practical contributors to the final output. 
 
-For each contributor, the following basic personal information should be provided:
+For each contributor, the following basic personal information should then be provided:
 - Name and Surname
 - Affiliation
-- Open Researcher and Contributor ID ([ORCiD](<https://orcid.org/>)) code
-- CRediT role (contribution provided to the research).
+- Open Researcher and Contributor ID ([ORCiD][3]]) code
+- CRediT role
+
+[Brand et al. (2015)][2] defined the [CRediT roles][2] as follows:
+| Term | Definition|
+| :--: | :-------- |
+| Conceptualization | Ideas; formulation or evolution of overarching research goals and aims|
+| Methodology | Development or design of methodology; creation of models|
+| Software | Programming, software development; designing computer programs; implementation of the computer code and supporting algorithms; testing of existing code components|
+| Validation | Verification, whether as a part of the activity or separate, of the overall replication/ reproducibility of results/experiments and other research outputs |
+| Formal analysis | Application of statistical, mathematical, computational, or other formal techniques to analyze or synthesize study data |
+| Investigation | Conducting a research and investigation process, specifically performing the experiments, or data/evidence collection |
+| Resources | Provision of study materials, reagents, materials, patients, laboratory samples, animals, instrumentation, computing resources, or other analysis tools |
+| Data Curation | Management activities to annotate (produce metadata), scrub data and maintain research data (including software code, where it is necessary for interpreting the data itself) for initial use and later reuse|
+| Writing - Original Draft | Preparation, creation and/or presentation of the published work, specifically writing the initial draft (including substantive translation) |
+| Writing - Review & Editing | Preparation, creation and/or presentation of the published work by those from the original research group, specifically critical review, commentary or revision – including pre-or postpublication stages |
+| Visualization | Preparation, creation and/or presentation of the published work, specifically visualization/ data presentation | 
+| Supervision | Oversight and leadership responsibility for the research activity planning and execution, including mentorship external to the core team |
+| Project administration | Management and coordination responsibility for the research activity planning and execution |
+| Funding acquisition | Acquisition of the financial support for the project leading to this publication |
+
+# Useful resources
+From [*The Turing Way*](https://the-turing-way.netlify.app/welcome.html) handbook to reproducible, ethical and collaborative data science:
+- Section on [**Authorship and Contributions on Academic Articles**][6], with reflections on the ethical aspects of authorship.
 
 
 
-[1]: <https://onlinelibrary.wiley.com/doi/10.1087/20150211> "Brand, A., Allen, L., Altman, M., Hlava, M., Scott, J., 2015. Beyond authorship: attribution, contribution, collaboration and credit. *Learned Publishing*, 28: 151–155. DOI:10.1087/20150211"
+------------
+*This material is derived from the [CCG review of good enough practices][4], released under a [CC-BY 4.0 license][5].*
 
-</div>
+[1]: https://www.elsevier.com/authors/policies-and-guidelines/credit-author-statement
+
+[2]: https://onlinelibrary.wiley.com/doi/10.1087/20150211 "Brand, A., Allen, L., Altman, M., Hlava, M., Scott, J., 2015. Beyond authorship: attribution, contribution, collaboration and credit. *Learned Publishing*, 28: 151–155. DOI:10.1087/20150211"
+
+[3]: https://orcid.org/
+
+[4]: https://doi.org/10.5281/zenodo.5911546 "Usher, William, Beltramo, Agnese, Gardumi, Francesco, Martin, Viktoria, & Petrarulo, Luca. (2022). CCG Platform - Body of Knowledge: Review of Good Practice (1.3). Zenodo. https://doi.org/10.5281/zenodo.5911546"
+
+[5]: https://creativecommons.org/licenses/by/4.0/legalcode
+[6]: https://the-turing-way.netlify.app/communication/aa.html

--- a/_posts/2022-02-01-attribution.md
+++ b/_posts/2022-02-01-attribution.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "Attribution"
+date:   2022-02-01 
+author: Agnese Beltramo
+category: Open Science
+tags: attribution
+---
+
+<div style="text-align: justify">
+More and more often, contemporary research is conducted by a number of young and senior researchers actively collaborating and contributing to a common project, answering an increasingly multidisplinary range of questions. 
+
+To ensure all the people involved in the research process are rightfully acknolwegded, the [Contributor Roles Taxonomy, known as CRediT author statement][1] was created. The CRediT taxonomy clearlry provides definitions for a wide range of roles to describe the personal contributions that a researcher might bring to a collaborative project. It also aims at providing a definition for what authorship should mean and acknowledge, in the case of scientific research, by broadening the concept to include all intellectual and practical contributors to the final output. 
+
+For each contributor, the following basic personal information should be provided:
+- Name and Surname
+- Affiliation
+- Open Researcher and Contributor ID ([ORCiD](<https://orcid.org/>)) code
+- CRediT role (contribution provided to the research).
+
+
+
+[1]: <https://onlinelibrary.wiley.com/doi/10.1087/20150211> "Brand, A., Allen, L., Altman, M., Hlava, M., Scott, J., 2015. Beyond authorship: attribution, contribution, collaboration and credit. *Learned Publishing*, 28: 151–155. DOI:10.1087/20150211"
+
+</div>


### PR DESCRIPTION
Adding guideline on Attribution. Focusing on basic info about CRediT and related literature.
Should I add all the CRediT taxonomy? I think that would be redundant.
 